### PR TITLE
FLC-143 ✨ 상세페이지 연결

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -12,6 +12,7 @@ import Join from "./pages/Join";
 import MyPage from "./pages/Mypage";
 import Favorites from "./pages/Favorites";
 import Test from "./tests/Test";
+import Detail from "./pages/Detail";
 
 // global styled-component
 const GlobalStyle = createGlobalStyle`
@@ -113,7 +114,10 @@ function App() {
             <Route path="mypage">
               <Route index element={<MyPage />} />
             </Route>
+            {/* 즐겨찾기 */}
             <Route path="favorites" index element={<Favorites />} />
+            {/* 상세페이지(덱마다 다른 id) */}
+            <Route path="detail/:id" element={<Detail />} />
           </Routes>
         </BrowserRouter>
       </MetaProvider>

--- a/src/assets/icon/dislike.svg
+++ b/src/assets/icon/dislike.svg
@@ -1,5 +1,4 @@
-<svg width="30" height="25" viewBox="0 0 30 25" fill="none" xmlns="http://www.w3.org/2000/svg">
-<rect width="30" height="25" rx="12.5" fill="#E0E0E0"/>
-<path d="M18.716 14.2938H21.0762V7.99998H18.716V14.2938Z" stroke="#7A7A7A" stroke-miterlimit="10" stroke-linejoin="round"/>
-<path d="M16.8672 14.2939L14.9004 16.2608L14.1137 19.0143C13.2447 19.0143 12.5402 18.3098 12.5402 17.4408V14.2939H10.5734C9.70448 14.2939 8.99997 13.5894 8.99997 12.7205L9.67694 8.65748C9.74027 8.27828 10.0687 8.00017 10.453 8.00017H16.8672V14.2939Z" stroke="#7A7A7A" stroke-miterlimit="10" stroke-linejoin="round"/>
+<svg width="19" height="17" viewBox="0 0 19 17" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M14.4407 9.47101H17.7051V0.766114H14.4407V9.47101Z" stroke="#3D3D3D" stroke-width="1.19232" stroke-miterlimit="10" stroke-linejoin="round"/>
+<path d="M11.8789 9.47133L9.15863 12.1916L8.07052 16C6.8687 16 5.89429 15.0256 5.89429 13.8238V9.47133H3.17401C1.97219 9.47133 0.99779 8.49692 0.99779 7.2951L1.93411 1.67555C2.0217 1.15108 2.47599 0.766434 3.00753 0.766434H11.8789V9.47133Z" stroke="#3D3D3D" stroke-width="1.19232" stroke-miterlimit="10" stroke-linejoin="round"/>
 </svg>

--- a/src/assets/icon/dislike_click.svg
+++ b/src/assets/icon/dislike_click.svg
@@ -1,0 +1,4 @@
+<svg width="19" height="17" viewBox="0 0 19 17" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M14.4407 9.47101H17.7051V0.766114H14.4407V9.47101Z" fill="#3D3D3D" stroke="#3D3D3D" stroke-width="1.19232" stroke-miterlimit="10" stroke-linejoin="round"/>
+<path d="M11.8789 9.47133L9.15863 12.1916L8.07052 16C6.8687 16 5.89429 15.0256 5.89429 13.8238V9.47133H3.17401C1.97219 9.47133 0.99779 8.49692 0.99779 7.2951L1.93411 1.67555C2.0217 1.15108 2.47599 0.766434 3.00753 0.766434H11.8789V9.47133Z" fill="#3D3D3D" stroke="#3D3D3D" stroke-width="1.19232" stroke-miterlimit="10" stroke-linejoin="round"/>
+</svg>

--- a/src/assets/icon/like.svg
+++ b/src/assets/icon/like.svg
@@ -1,5 +1,4 @@
-<svg width="30" height="25" viewBox="0 0 30 25" fill="none" xmlns="http://www.w3.org/2000/svg">
-<rect width="30" height="25" rx="12.5" fill="#5661FF"/>
-<path d="M11.3602 10.7204H9V17.0142H11.3602V10.7204Z" stroke="white" stroke-miterlimit="10" stroke-linejoin="round"/>
-<path d="M13.209 10.7203L15.1758 8.75352L15.9625 6C16.8314 6 17.536 6.70451 17.536 7.57344V10.7203H19.5028C20.3717 10.7203 21.0762 11.4248 21.0762 12.2938L20.3992 16.3568C20.3359 16.736 20.0074 17.0141 19.6231 17.0141H13.209V10.7203Z" stroke="white" stroke-miterlimit="10" stroke-linejoin="round"/>
+<svg width="19" height="17" viewBox="0 0 19 17" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M4.84441 7.52887H1.58008V16.2338H4.84441V7.52887Z" fill="white" stroke="#3D3D3D" stroke-width="1.19232" stroke-miterlimit="10" stroke-linejoin="round"/>
+<path d="M7.40039 7.52866L10.1207 4.80839L11.2088 1C12.4106 1 13.385 1.9744 13.385 3.17622V7.52866H16.1053C17.3071 7.52866 18.2815 8.50307 18.2815 9.70488L17.3452 15.3244C17.2576 15.8489 16.8033 16.2335 16.2718 16.2335H7.40039V7.52866Z" fill="white" stroke="#3D3D3D" stroke-width="1.19232" stroke-miterlimit="10" stroke-linejoin="round"/>
 </svg>

--- a/src/assets/icon/like_click.svg
+++ b/src/assets/icon/like_click.svg
@@ -1,0 +1,4 @@
+<svg width="19" height="17" viewBox="0 0 19 17" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M4.84441 7.52887H1.58008V16.2338H4.84441V7.52887Z" fill="#3D3D3D" stroke="#3D3D3D" stroke-width="1.19232" stroke-miterlimit="10" stroke-linejoin="round"/>
+<path d="M7.40039 7.52866L10.1207 4.80839L11.2088 1C12.4106 1 13.385 1.9744 13.385 3.17622V7.52866H16.1053C17.3071 7.52866 18.2815 8.50307 18.2815 9.70488L17.3452 15.3244C17.2576 15.8489 16.8033 16.2335 16.2718 16.2335H7.40039V7.52866Z" fill="#3D3D3D" stroke="#3D3D3D" stroke-width="1.19232" stroke-miterlimit="10" stroke-linejoin="round"/>
+</svg>

--- a/src/assets/icon/line.svg
+++ b/src/assets/icon/line.svg
@@ -1,0 +1,3 @@
+<svg width="2" height="17" viewBox="0 0 2 17" fill="none" xmlns="http://www.w3.org/2000/svg">
+<line x1="1.00202" y1="-1.51142e-08" x2="1.00202" y2="16.6925" stroke="#797979" stroke-width="0.691548"/>
+</svg>

--- a/src/components/common/Meta.tsx
+++ b/src/components/common/Meta.tsx
@@ -10,6 +10,7 @@ import sionImg from "../../assets/img/sion.jpg";
 import useSynergyColor from "../../hooks/useSynergyColor";
 import useChampionColor from "../../hooks/useChampionColor";
 import { ChampionsForm, ListForm, SynergysListForm } from "../../types/List";
+import usePreference from "../../hooks/usePreference";
 
 const Table = styled.table<{ border: string }>`
   font-size: 0.875rem; // 14px
@@ -270,16 +271,7 @@ export default function Meta({ metaData }: any) {
             {/* 선호도 */}
             <td>
               <h2>
-                {(item?.meta.like_count || 0) +
-                  (item?.meta.dislike_count || 0) ===
-                0
-                  ? 0 // like_count와 dislike_count 합이 0이면 0% 반환
-                  : Math.round(
-                      ((item?.meta.like_count || 0) /
-                        ((item?.meta.like_count || 0) +
-                          (item?.meta.dislike_count || 0))) *
-                        100,
-                    )}
+                {usePreference(item?.meta.like_count, item?.meta.dislike_count)}
                 %
               </h2>
             </td>

--- a/src/components/common/Meta.tsx
+++ b/src/components/common/Meta.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect } from "react";
 import styled from "styled-components";
-import { useLocation } from "react-router-dom";
+import { useLocation, useNavigate } from "react-router-dom";
 import { useMetaContext } from "../../hooks/Context";
 import heartEmptyImg from "../../assets/icon/heart_empty.svg";
 import heartFillImg from "../../assets/icon/heart_fill.svg";
@@ -181,6 +181,12 @@ export default function Meta({ metaData }: any) {
     }
   }, [metaData, setPickData]);
 
+  const navigate = useNavigate();
+
+  const handleClick = (id: number) => {
+    navigate(`/detail/${id}`);
+  };
+
   return (
     <Table border={border}>
       <Thead bgColor={bgColor}>
@@ -193,9 +199,13 @@ export default function Meta({ metaData }: any) {
           <th> </th>
         </tr>
       </Thead>
-      <Tbody hoverColor={hoverColor} evenColor={evenColor}>
-        {/* item : meta, synerge */}
-        {metaData.map((item: ListForm) => (
+      {/* item : meta, synerge */}
+      {metaData.map((item: ListForm) => (
+        <Tbody
+          hoverColor={hoverColor}
+          evenColor={evenColor}
+          onClick={() => handleClick(item?.meta.id)}
+        >
           <tr key={item?.meta.id}>
             {/* 별 */}
             <td>
@@ -278,8 +288,8 @@ export default function Meta({ metaData }: any) {
               <img src={arrowImg} alt="화살표" />
             </td>
           </tr>
-        ))}
-      </Tbody>
+        </Tbody>
+      ))}
     </Table>
   );
 }

--- a/src/components/containers/Footer.tsx
+++ b/src/components/containers/Footer.tsx
@@ -39,7 +39,7 @@ const Contents = styled.div`
 `;
 const Copyright = styled.span`
   color: #7c7c7c;
-  font-size: 10px;
+  font-size: 11px;
   line-height: 18px;
 `;
 
@@ -100,7 +100,7 @@ export default function Footer() {
       <ArrowUp src={arrowUPImg} alt="위쪽" onClick={() => handleTop()} />
       <Main>
         <Contents>
-          <h1>Find Lol Chess</h1>
+          <h1>FLC</h1>
           <Copyright>
             <p>© FindLolChess. All Rights Reserved.</p>
             <p>

--- a/src/hooks/usePreference.tsx
+++ b/src/hooks/usePreference.tsx
@@ -1,0 +1,5 @@
+// 기본값 0으로 지정
+export default function usePreference(like = 0, dislike = 0) {
+  const total = like + dislike;
+  return total === 0 ? 0 : Math.round((like / total) * 100);
+}

--- a/src/pages/Detail.tsx
+++ b/src/pages/Detail.tsx
@@ -1,6 +1,7 @@
 import styled from "styled-components";
 import { useEffect, useState } from "react";
 import { useParams } from "react-router-dom";
+import restartImg from "../assets/icon/restart.svg";
 import chessImg from "../assets/icon/chess.svg";
 import blackImg from "../assets/icon/heart_black.svg";
 import redImg from "../assets/icon/heart_red.svg";
@@ -20,6 +21,7 @@ const Body = styled.div`
   flex-direction: column;
   min-height: 100vh;
 `;
+
 const Main = styled.main`
   flex: 1;
   background-color: #f4f4f4;
@@ -29,6 +31,7 @@ const Main = styled.main`
   gap: 19px;
   padding: 25px 0 60px;
 `;
+
 const SynergyBox = styled.ul`
   display: flex;
   gap: 3px;
@@ -47,6 +50,7 @@ const Synergy = styled.li`
   border-radius: 5px;
   background: #fff;
 `;
+
 const Contents = styled.div`
   display: flex;
   gap: 16px;
@@ -57,15 +61,34 @@ const ChessBox = styled.div`
   background: #fff;
   box-shadow: 0px 4px 36px -14px rgba(0, 0, 0, 0.05);
 `;
+const Top = styled.div`
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding-left: 36px;
+  padding-right: 28px;
+  height: 66px;
+`;
 const Title = styled.div`
   display: flex;
   gap: 8px;
   align-items: center;
-  padding-left: 36px;
-  height: 66px;
   font-size: 22px;
   font-weight: 600;
   cursor: pointer;
+`;
+const RestartBox = styled.div`
+  display: flex;
+  align-items: flex-start;
+  gap: 0.125rem; // 2px
+  width: 2.6875rem; // 43px
+  height: 1.25rem; // 20px
+  border-radius: 0.3125rem; // 5px
+  border: 0.0625rem solid #000; // 1px
+  padding: 0.25rem 0.4375rem; // 4px 7px
+  margin-top: 4px;
+  font-size: 0.625rem; // 10px
+  font-weight: 500;
 `;
 const Line = styled.div`
   width: 804px;
@@ -184,10 +207,16 @@ export default function Detail() {
         </SynergyBox>
         <Contents>
           <ChessBox>
-            <Title>
-              <img src={blackImg} alt="빈하트" />
-              {item?.meta.title}
-            </Title>
+            <Top>
+              <Title>
+                <img src={blackImg} alt="빈하트" />
+                {item?.meta.title}
+              </Title>
+              <RestartBox>
+                <img src={restartImg} alt="리롤" />
+                lvl{item?.meta.reroll_lv}
+              </RestartBox>
+            </Top>
             <Line />
             <ChampionContents>{champions}</ChampionContents>
           </ChessBox>

--- a/src/pages/Detail.tsx
+++ b/src/pages/Detail.tsx
@@ -13,6 +13,7 @@ import Header from "../components/containers/Header";
 import Footer from "../components/containers/Footer";
 import { Api } from "../utils/apis/Api";
 import { ListForm } from "../types/List";
+import usePreference from "../hooks/usePreference";
 
 const Body = styled.div`
   display: flex;
@@ -196,7 +197,8 @@ export default function Detail() {
               <LikeButton>
                 <img src={likeImg} alt="좋아요" />
                 <img src={lineImg} alt="실선" />
-                100%
+                {usePreference(item?.meta.like_count, item?.meta.dislike_count)}
+                %
                 <img src={dislikeImg} alt="싫어요" />
               </LikeButton>
             </CommentTitle>

--- a/src/pages/Detail.tsx
+++ b/src/pages/Detail.tsx
@@ -1,18 +1,37 @@
 import styled from "styled-components";
+import { useEffect, useState } from "react";
+import { useParams } from "react-router-dom";
 import chessImg from "../assets/icon/chess.svg";
 import blackImg from "../assets/icon/heart_black.svg";
 import redImg from "../assets/icon/heart_red.svg";
 import likeImg from "../assets/icon/like.svg";
+import likeClickImg from "../assets/icon/like_click.svg";
 import dislikeImg from "../assets/icon/dislike.svg";
+import dislikeClickImg from "../assets/icon/dislike_click.svg";
+import lineImg from "../assets/icon/line.svg";
+import Header from "../components/containers/Header";
+import Footer from "../components/containers/Footer";
+import { Api } from "../utils/apis/Api";
+import { ListForm } from "../types/List";
 
 const Body = styled.div`
   display: flex;
   flex-direction: column;
   min-height: 100vh;
 `;
+const Main = styled.main`
+  flex: 1;
+  background-color: #f4f4f4;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 19px;
+  padding: 25px 0 60px;
+`;
 const SynergyBox = styled.ul`
   display: flex;
   gap: 3px;
+  width: 1195px;
   height: 30px;
   padding-left: 26px;
   font-size: 12px;
@@ -59,7 +78,7 @@ const ChampionContents = styled.div`
   grid-template-columns: repeat(7, 91px); // 고정된 칸 너비
   grid-template-rows: repeat(4, 91px); // 고정된 칸 높이
   column-gap: 10px; // 한 줄 내 칸 사이 간격
-  row-gap: 5px; // 줄과 줄 사이 간격
+  row-gap: 8px; // 줄과 줄 사이 간격
 `;
 const ChessChampion = styled.div`
   display: flex;
@@ -93,25 +112,44 @@ const Comment = styled.div`
 const CommentTitle = styled.div`
   height: 66px;
   border-bottom: 1px solid #c9c9c9;
-  font-size: 15px;
-  font-weight: 400;
   padding: 14px 19px;
+
   > h4 {
-    font-size: 14px;
-    font-weight: 500;
+    font-size: 13px;
+    font-weight: 600;
+    color: #000;
   }
 `;
 const LikeButton = styled.div`
   display: flex;
-  gap: 3px;
+  gap: 4px;
   align-items: center;
-  padding-top: 6px;
+  padding-top: 10px;
+  font-size: 14px;
+  font-weight: 500;
+  color: #3d3d3d;
+  font-family: "Roboto";
   > img {
     cursor: pointer;
   }
 `;
 export default function Detail() {
-  const champions = [];
+  const { id } = useParams(); // URL에서 id 값 가져오기
+  const [item, setItem] = useState<ListForm>();
+  useEffect(() => {
+    const searchApi = async () => {
+      const response = await Api({
+        bodyData: { data: id }, // 내 코드에선 search라는 이름이지만 DB에선 data라는 이름으로 받아서 변경해줌
+        method: "POST",
+        lastUrl: "meta/metasearch/",
+      });
+      setItem(response.data[0]);
+      console.log(response.data[0]);
+    };
+    searchApi();
+  }, []);
+
+  const champions = []; // 챔피언 박스 배열
   for (let i = 0; i < 28; i += 1) {
     champions.push(
       <ChessChampion key={i}>
@@ -122,43 +160,52 @@ export default function Detail() {
 
   return (
     <Body>
-      <SynergyBox>
-        <Synergy>
-          <img src="" alt="시너지" />
-          <p>4</p>
-          선도자
-        </Synergy>
-        <Synergy>
-          <img src="" alt="시너지" />
-          <p>8</p>
-          마법사
-        </Synergy>
-        <Synergy>
-          <img src="" alt="시너지" />
-          <p>3</p>
-          정복자
-        </Synergy>
-      </SynergyBox>
-      <Contents>
-        <ChessBox>
-          <Title>
-            <img src={blackImg} alt="빈하트" />
-            초반 빌드 레넥톤 워윅
-          </Title>
-          <Line />
-          <ChampionContents>{champions}</ChampionContents>
-        </ChessBox>
-        <Comment>
-          <CommentTitle>
-            <h4>덱이 마음에 드셨나요?</h4>
-            <LikeButton>
-              <img src={likeImg} alt="좋아요" />
-              <img src={dislikeImg} alt="싫어요" />
-              100%
-            </LikeButton>
-          </CommentTitle>
-        </Comment>
-      </Contents>
+      <header>
+        <Header />
+      </header>
+      <Main>
+        <SynergyBox>
+          <Synergy>
+            <img src="" alt="시너지" />
+            <p>4</p>
+            선도자
+          </Synergy>
+          <Synergy>
+            <img src="" alt="시너지" />
+            <p>8</p>
+            마법사
+          </Synergy>
+          <Synergy>
+            <img src="" alt="시너지" />
+            <p>3</p>
+            정복자
+          </Synergy>
+        </SynergyBox>
+        <Contents>
+          <ChessBox>
+            <Title>
+              <img src={blackImg} alt="빈하트" />
+              {item?.meta.title}
+            </Title>
+            <Line />
+            <ChampionContents>{champions}</ChampionContents>
+          </ChessBox>
+          <Comment>
+            <CommentTitle>
+              <h4>덱이 마음에 드셨나요?</h4>
+              <LikeButton>
+                <img src={likeImg} alt="좋아요" />
+                <img src={lineImg} alt="실선" />
+                100%
+                <img src={dislikeImg} alt="싫어요" />
+              </LikeButton>
+            </CommentTitle>
+          </Comment>
+        </Contents>
+      </Main>
+      <footer>
+        <Footer />
+      </footer>
     </Body>
   );
 }


### PR DESCRIPTION
*상세페이지 특징
: 메타의 id에 따라 주소가 다른 페이지가 생성. 디자인은 동일.

- 동적 라우팅 연결 : "Route path="detail/:id"의 형태로 라우터에 생성하고, 기존 메타를 onClick하면 이동할 수 있도록 useNavigate사용.
- useParams 이용 : 생성된 페이지에 알맞게 상세페이지를 보여주기 위해 같은 DetailPage 디자인을 바탕으로 다른 정보를 불러올 수 있도록 구성
- 상세페이지<선호도> : 기존 메타에서 사용한 방식(좋아요와 싫어요 갯수를 토대로 만든 선호도 비율을 도출)을 함수화하여 usePreference로 만든 뒤 사용.
- 상세페이지<리롤레벨> : 기존 메타에서 사용한 리롤레벨 박스형식을 상세페이지에도 적용.
- 푸터 디자인 변경 : 글자 크기, 문구 변경