### PR TITLE
FLC-144, FLC-147, FLC-148 ✨ 상세페이지 시너지와 빠른챔피언 취소, 비활성화, 체크

### DIFF
--- a/src/assets/icon/heart_red.svg
+++ b/src/assets/icon/heart_red.svg
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<svg viewBox="0 0 25 25" width="25" height="25" xmlns="http://www.w3.org/2000/svg">
+<svg viewBox="0 0 256 256" width="25" height="25" xmlns="http://www.w3.org/2000/svg">
       <rect fill="none" height="25" width="25"></rect>
       <path
         d="M224.6,51.9a59.5,59.5,0,0,0-43-19.9,60.5,60.5,0,0,0-44,17.6L128,59.1l-7.5-7.4C97.2,28.3,59.2,26.3,35.9,47.4a59.9,59.9,0,0,0-2.3,87l83.1,83.1a15.9,15.9,0,0,0,22.6,0l81-81C243.7,113.2,245.6,75.2,224.6,51.9Z"
         stroke-width="20px"
-        stroke="red"
+        stroke="none"
         fill="red"
       ></path>
     </svg>

--- a/src/components/Carousel.tsx
+++ b/src/components/Carousel.tsx
@@ -186,6 +186,10 @@ export default function Carousel() {
   const handleImage = () => {
     navigate("/recommend-list");
   };
+  // 캐러셀 내용 누르면 동작
+  const handleClick = (id: number) => {
+    navigate(`/detail/${id}`);
+  };
 
   // 버튼들 : slide 값을 변경하여 슬라이드를 전환
   // 오른쪽 버튼 누르면 동작
@@ -230,7 +234,7 @@ export default function Carousel() {
         <ImageBox onClick={() => handleImage()}>
           <BackImage src={bgImage3} alt="캐러셀 이미지3" />
         </ImageBox>
-        <MetaBox>
+        <MetaBox onClick={() => handleClick(metaData[2]?.meta?.id)}>
           <p>{metaData[2]?.meta?.title}</p>
           <SynergyBox>
             {metaData[2]?.synergys.map(synergyGroup =>
@@ -277,7 +281,7 @@ export default function Carousel() {
         <ImageBox onClick={() => handleImage()}>
           <BackImage src={bgImage1} alt="캐러셀 이미지1" />
         </ImageBox>
-        <MetaBox>
+        <MetaBox onClick={() => handleClick(metaData[0]?.meta?.id)}>
           <p>{metaData[0]?.meta?.title}</p>
           <SynergyBox>
             {metaData[0]?.synergys.map(synergyGroup =>
@@ -324,7 +328,7 @@ export default function Carousel() {
         <ImageBox onClick={() => handleImage()}>
           <BackImage src={bgImage2} alt="캐러셀 이미지2" />
         </ImageBox>
-        <MetaBox>
+        <MetaBox onClick={() => handleClick(metaData[1]?.meta?.id)}>
           <p>{metaData[1]?.meta?.title}</p>
           <SynergyBox>
             {metaData[1]?.synergys.map(synergyGroup =>

--- a/src/components/Fast.tsx
+++ b/src/components/Fast.tsx
@@ -7,6 +7,7 @@ import useChampionColor from "../hooks/useChampionColor";
 import championBannerImg from "../assets/img/champion_banner.jpg";
 import arrowFillImg from "../assets/icon/arrow_fill.svg";
 import downImg from "../assets/icon/arrow_down.svg";
+import checkImg from "../assets/icon/check.svg";
 
 const Body = styled.section`
   margin-top: 60px;
@@ -100,6 +101,13 @@ const ChampionImg = styled.img<{ filter: string; color: string }>`
   border: 2.5px solid ${props => props.color};
   filter: ${props => props.filter};
 `;
+const CheckImg = styled.img`
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -80%);
+  z-index: 2;
+`;
 
 const arrowAnimation = keyframes`
   0% {
@@ -138,13 +146,14 @@ export default function Fast({
 }) {
   const [championData, setChampionData] = useState([]); // Fast표에 챔피언을 보여주기 위한 데이터
   const [groupPrice, setGroupPrice] = useState<number[]>([]); // Fast표에서 가격별로 구분해주기 위한 그룹
-  const [selectName, setSelectName] = useState<string[]>([]);
+  const [selectName, setSelectName] = useState<string[]>([]); // 선택된 챔피언의 이름을 모아둔 배열
   const [mono, setMono] = useState(true); // 흑백처러(false면 흑백)
 
   const { pickData } = useMetaContext(); // PickData를 통해 Meta에 받아온 정보가 저장되어 있음
 
   // 처음 실행
   useEffect(() => {
+    // 챔피언 리스트에 챔피언 불러오기
     const championApi = async () => {
       const response = await Api({
         method: "GET",
@@ -179,6 +188,7 @@ export default function Fast({
     });
   };
 
+  // 메타 불러오기
   const sendPickMeta = async (names: string) => {
     const pickData = await Api({
       bodyData: { data: names },
@@ -192,6 +202,7 @@ export default function Fast({
     }
   };
 
+  // 스크롤
   const handleDown = () => {
     window.scrollTo({
       top: 1100,
@@ -236,6 +247,9 @@ export default function Fast({
                             : "grayscale(1)"
                         }
                       />
+                      {selectName.includes(item.name) && (
+                        <CheckImg src={checkImg} alt="체크 표시" />
+                      )}
                       <p>{item?.name}</p>
                       <Tooltip className="tooltip">{item?.name}</Tooltip>
                     </Champion>

--- a/src/components/Fast.tsx
+++ b/src/components/Fast.tsx
@@ -146,8 +146,7 @@ export default function Fast({
 }) {
   const [championData, setChampionData] = useState([]); // Fast표에 챔피언을 보여주기 위한 데이터
   const [groupPrice, setGroupPrice] = useState<number[]>([]); // Fast표에서 가격별로 구분해주기 위한 그룹
-  const [selectName, setSelectName] = useState<string[]>([]); // 선택된 챔피언의 이름을 모아둔 배열
-  const [mono, setMono] = useState(true); // 흑백처러(false면 흑백)
+  const [selectName, setSelectName] = useState<string[]>([]); // 내가 선택한 챔피언의 이름을 모아둔 배열
 
   const { pickData } = useMetaContext(); // PickData를 통해 Meta에 받아온 정보가 저장되어 있음
 
@@ -168,7 +167,7 @@ export default function Fast({
 
   // pickData 상태가 변경될 때마다 실행
   useEffect(() => {
-    console.log(pickData);
+    // console.log(pickData);
   }, [pickData]);
 
   const handleClick = (name: string) => {
@@ -177,10 +176,11 @@ export default function Fast({
       const index = updatedNames.indexOf(name); // 배열안에 name이 있는지 확인 (0이하면 없음 양수면 있음)
       if (index < 0) {
         updatedNames.push(name); // 이전 값에 새 name 추가
-        setMono(false); // 전체 흑백
       } else {
         updatedNames.splice(index, 1); // 중복이면 배열에서 제거 (index번째로부터 1개)
-        setMono(true); // 전체 컬러
+      }
+      if (updatedNames) {
+        pickData.includes(name);
       }
       const names = updatedNames.join(","); // 배열을 ','로 합친 문자열로 변경하고 생성
       sendPickMeta(names); // API 호출
@@ -200,6 +200,16 @@ export default function Fast({
     } else {
       setPickMeta("");
     }
+  };
+
+  const handleMono = (name: string) => {
+    if (selectName.length === 0) {
+      return true;
+    }
+    if (pickData.includes(name)) {
+      return true;
+    }
+    return false;
   };
 
   // 스크롤
@@ -241,11 +251,7 @@ export default function Fast({
                         src={item?.img.img_src}
                         alt="챔피언"
                         color={useChampionColor(item.price)}
-                        filter={
-                          mono || pickData.includes(item.name)
-                            ? "none"
-                            : "grayscale(1)"
-                        }
+                        filter={handleMono(item.name) ? "none" : "grayscale(1)"}
                       />
                       {selectName.includes(item.name) && (
                         <CheckImg src={checkImg} alt="체크 표시" />

--- a/src/components/Fast.tsx
+++ b/src/components/Fast.tsx
@@ -100,6 +100,9 @@ const ChampionImg = styled.img<{ filter: string; color: string }>`
   border-radius: 0.25rem; // 4px
   border: 2.5px solid ${props => props.color};
   filter: ${props => props.filter};
+  // 클릭 방지 & 비활성화 스타일 추가
+  cursor: ${({ filter }) =>
+    filter.includes("grayscale") ? "not-allowed" : "pointer"};
 `;
 const CheckImg = styled.img`
   position: absolute;
@@ -245,7 +248,11 @@ export default function Fast({
                   .map((item: ChampionDataForm) => (
                     <Champion
                       key={item?.name}
-                      onClick={() => handleClick(item?.name)}
+                      onClick={
+                        handleMono(item.name)
+                          ? () => handleClick(item?.name)
+                          : undefined
+                      }
                     >
                       <ChampionImg
                         src={item?.img.img_src}

--- a/src/components/Fast.tsx
+++ b/src/components/Fast.tsx
@@ -148,6 +148,7 @@ export default function Fast({
   setPickMeta: (value: string) => void;
 }) {
   const [championData, setChampionData] = useState([]); // Fast표에 챔피언을 보여주기 위한 데이터
+  const [championPickData, setChampionPickData] = useState<string[]>([]); // Fast표에 챔피언 흑백나눠서 보여주기 위한 데이터
   const [groupPrice, setGroupPrice] = useState<number[]>([]); // Fast표에서 가격별로 구분해주기 위한 그룹
   const [selectName, setSelectName] = useState<string[]>([]); // 내가 선택한 챔피언의 이름을 모아둔 배열
 
@@ -157,12 +158,21 @@ export default function Fast({
   useEffect(() => {
     // 챔피언 리스트에 챔피언 불러오기
     const championApi = async () => {
-      const response = await Api({
-        method: "GET",
-        lastUrl: "meta/championsearch/",
-      });
-      setChampionData(response.data);
-      const prices = response.data.map((item: ChampionDataForm) => item.price);
+      const [responseAll, responsePick] = await Promise.all([
+        Api({
+          method: "GET",
+          lastUrl: "meta/championsearch/",
+        }),
+        Api({
+          method: "GET",
+          lastUrl: "/meta/usechampionsearch/",
+        }),
+      ]);
+      setChampionData(responseAll.data);
+      setChampionPickData(responsePick.data);
+      const prices = responseAll.data.map(
+        (item: ChampionDataForm) => item.price,
+      );
       setGroupPrice(Array.from(new Set(prices))); // 중복 제거
     };
     championApi();
@@ -205,13 +215,21 @@ export default function Fast({
     }
   };
 
+  // 반환값이 false면 흑백
   const handleMono = (name: string) => {
+    // 처음 들어오는 챔피언 자체가 덱에 있는지 여부 없으면 흑백
+    if (!championPickData.includes(name)) {
+      return false;
+    }
+    // 선택된게 아무것도 없을때 컬러, 다시 다 취소해도 컬러 유지
     if (selectName.length === 0) {
       return true;
     }
+    // 내가 선택한거에 따라 선택했으면 컬러
     if (pickData.includes(name)) {
       return true;
     }
+    // 나머지 경우 다 흑백
     return false;
   };
 

--- a/src/components/containers/Footer.tsx
+++ b/src/components/containers/Footer.tsx
@@ -100,7 +100,7 @@ export default function Footer() {
       <ArrowUp src={arrowUPImg} alt="위쪽" onClick={() => handleTop()} />
       <Main>
         <Contents>
-          <h1>FLC</h1>
+          <h1>FindLolChess</h1>
           <Copyright>
             <p>© FindLolChess. All Rights Reserved.</p>
             <p>

--- a/src/components/containers/Footer.tsx
+++ b/src/components/containers/Footer.tsx
@@ -100,11 +100,11 @@ export default function Footer() {
       <ArrowUp src={arrowUPImg} alt="위쪽" onClick={() => handleTop()} />
       <Main>
         <Contents>
-          <h1>FindLolChess</h1>
+          <h1>Find Lol Chess</h1>
           <Copyright>
-            <p>© FindLolChess. All Rights Reserved.</p>
+            <p>© Find Lol Chess. All Rights Reserved.</p>
             <p>
-              FindLolChess isn&apos;t endorsed by Riot Games and doesn&apos;t
+              Find Lol Chess isn&apos;t endorsed by Riot Games and doesn&apos;t
               reflect the views or opinions of Riot Games or anyone officially
               involved in producing or managing League of Legends. League of
             </p>

--- a/src/pages/Detail.tsx
+++ b/src/pages/Detail.tsx
@@ -13,8 +13,9 @@ import lineImg from "../assets/icon/line.svg";
 import Header from "../components/containers/Header";
 import Footer from "../components/containers/Footer";
 import { Api } from "../utils/apis/Api";
-import { ListForm } from "../types/List";
+import { ListForm, SynergysListForm } from "../types/List";
 import usePreference from "../hooks/usePreference";
+import useSynergyColor from "../hooks/useSynergyColor";
 
 const Body = styled.div`
   display: flex;
@@ -50,6 +51,20 @@ const Synergy = styled.li`
   border-radius: 5px;
   background: #fff;
 `;
+const SynergyColor = styled.div<{ color: string }>`
+  background: url(${props => props.color});
+  background-size: contain;
+  background-repeat: no-repeat;
+  background-position: center;
+  width: 19px;
+  height: 19px;
+`;
+const SynergyImg = styled.img`
+  width: 10px;
+  height: 10px;
+  margin-top: 4px;
+  margin-left: 4px;
+`;
 
 const Contents = styled.div`
   display: flex;
@@ -79,15 +94,15 @@ const Title = styled.div`
 `;
 const RestartBox = styled.div`
   display: flex;
-  align-items: flex-start;
+  align-items: inherit;
   gap: 0.125rem; // 2px
-  width: 2.6875rem; // 43px
-  height: 1.25rem; // 20px
+  width: 49px;
+  height: 23px;
   border-radius: 0.3125rem; // 5px
   border: 0.0625rem solid #000; // 1px
-  padding: 0.25rem 0.4375rem; // 4px 7px
+  padding: 4px 8px;
   margin-top: 4px;
-  font-size: 0.625rem; // 10px
+  font-size: 11px;
   font-weight: 500;
 `;
 const Line = styled.div`
@@ -189,21 +204,28 @@ export default function Detail() {
       </header>
       <Main>
         <SynergyBox>
-          <Synergy>
-            <img src="" alt="시너지" />
-            <p>4</p>
-            선도자
-          </Synergy>
-          <Synergy>
-            <img src="" alt="시너지" />
-            <p>8</p>
-            마법사
-          </Synergy>
-          <Synergy>
-            <img src="" alt="시너지" />
-            <p>3</p>
-            정복자
-          </Synergy>
+          {/* 시너지 */}
+          {item?.synergys &&
+            Object.entries(item?.synergys[0]).map(([key, value]) => {
+              const colors = useSynergyColor(
+                value.number,
+                key,
+                value.effect,
+                value.sequence,
+              );
+              return colors ? (
+                <Synergy key={key}>
+                  <SynergyColor color={colors}>
+                    <SynergyImg
+                      src={value.img_src}
+                      alt={`${key} 시너지 무늬`}
+                    />
+                  </SynergyColor>
+                  <p>{value.number}</p>
+                  {key}
+                </Synergy>
+              ) : null;
+            })}
         </SynergyBox>
         <Contents>
           <ChessBox>

--- a/src/pages/Detail.tsx
+++ b/src/pages/Detail.tsx
@@ -175,6 +175,7 @@ const LikeButton = styled.div`
 export default function Detail() {
   const { id } = useParams(); // URL에서 id 값 가져오기
   const [item, setItem] = useState<ListForm>();
+  const [heart, setHeart] = useState(false); // 빈하트 false
   useEffect(() => {
     const searchApi = async () => {
       const response = await Api({
@@ -196,6 +197,10 @@ export default function Detail() {
       </ChessChampion>,
     );
   }
+
+  const handleHeart = () => {
+    setHeart(!heart);
+  };
 
   return (
     <Body>
@@ -231,7 +236,16 @@ export default function Detail() {
           <ChessBox>
             <Top>
               <Title>
-                <img src={blackImg} alt="빈하트" />
+                <img
+                  src={heart ? redImg : blackImg}
+                  alt="하트"
+                  onClick={handleHeart}
+                  onKeyDown={e => {
+                    if (e.key === "Enter" || e.key === " ") {
+                      handleHeart(); // Enter 키나 Space 키로 클릭을 대체
+                    }
+                  }}
+                />
                 {item?.meta.title}
               </Title>
               <RestartBox>

--- a/src/pages/Detail.tsx
+++ b/src/pages/Detail.tsx
@@ -35,7 +35,7 @@ const Main = styled.main`
 
 const SynergyBox = styled.ul`
   display: flex;
-  gap: 3px;
+  gap: 4px;
   width: 1195px;
   height: 30px;
   padding-left: 26px;
@@ -44,26 +44,30 @@ const SynergyBox = styled.ul`
 `;
 const Synergy = styled.li`
   display: flex;
-  gap: 2px;
+  padding: 6px;
   align-items: center;
   justify-content: center;
-  width: 100px;
   border-radius: 5px;
   background: #fff;
+  cursor: pointer;
+  > p {
+    padding-left: 2.5px;
+    padding-right: 2px;
+  }
 `;
 const SynergyColor = styled.div<{ color: string }>`
   background: url(${props => props.color});
   background-size: contain;
   background-repeat: no-repeat;
   background-position: center;
-  width: 19px;
-  height: 19px;
+  width: 20px;
+  height: 20px;
 `;
 const SynergyImg = styled.img`
-  width: 10px;
-  height: 10px;
-  margin-top: 4px;
-  margin-left: 4px;
+  width: 12px;
+  height: 12px;
+  margin-top: 3.5px;
+  margin-left: 3.5px;
 `;
 
 const Contents = styled.div`


### PR DESCRIPTION
1. 상세페이지 시너지
- 데이터에서 시너지 img_src, 시너지 배경색 정보, 시너지 number, 시너지 name을 받아옴
- 기존 사용하던 useSynergyColor를 이용하여 시너지 배경 색상 지정
2. 빠른 챔피언 취소
- 기존에 취소 시 전체원상복구만 가능한걸 부분 원상복구로 변경 : handleMono 함수를 만들어서 전체 컬러/흑백을 구분하는 if문(selectName)과 부분 컬러/흑백을 구분하는 if문(pickData)로 조건 세분화
- 처음부터 덱에 없는 챔피언 처리 : useEffect에 usechampionsearch API를 get받아와서 setChampionPickData에 저장하고, handleMono 함수에서 현재 메타와 비교하여 없을 시 처음부터 흑백으로 보이도록 if 조건
3. 빠른 챔피언 비활성화
- handleMono로 기능 부분과 filter를 받아와서 css처리하는 디자인 부분을 분리 : 컬러/흑백 관련 모든 디자인을 한 번에 할 수 있도록 함
- disabled css : 마우스 호버 시 금지 표시, 클릭 불가능, 흑백
4. 빠른 챔피언 체크
- 체크 기능 : 사용자가 현재 무슨 챔피언을 눌렀는지 표시해주기 위한 기., 다시 한 번 더 클릭 시 체크 해제. 체크 표시는 챔피언 사진의 정 가운데에 위치.
5. 그 외
- 캐러셀 타이틀 부분 상세페이지로 가는 링크 연결
- 푸터 디자인 변경
- 상세페이지 즐겨찾기 디자인