### PR TITLE
FLC-146, FLC-156✨ Choice

### DIFF
--- a/src/assets/icon/info.svg
+++ b/src/assets/icon/info.svg
@@ -1,0 +1,5 @@
+<svg width="66" height="66" viewBox="0 0 66 66" fill="none" xmlns="http://www.w3.org/2000/svg">
+<circle cx="33" cy="33" r="31.5" stroke="#5D5D5D" stroke-width="3"/>
+<rect x="31.3501" y="17.325" width="3.3" height="22.275" fill="#5D5D5D"/>
+<rect x="31.3501" y="45.375" width="3.3" height="3.3" fill="#5D5D5D"/>
+</svg>

--- a/src/components/Chat.tsx
+++ b/src/components/Chat.tsx
@@ -73,7 +73,7 @@ const ThreeButton = styled.div`
   }
 `;
 const NoBox = styled.div`
-  margin: auto;
+  margin: 120px 45px 10px 30px;
   padding: 12px;
   background: #5661ff;
   border-radius: 8px;

--- a/src/components/Chat.tsx
+++ b/src/components/Chat.tsx
@@ -105,6 +105,7 @@ export default function Chat(metaid: any) {
   const token = getCookie("token"); // 현재 토큰
 
   useEffect(() => {
+    if (!token) return;
     const searchApi = async () => {
       const [responseContext, responseNickname] = await Promise.all([
         Api({

--- a/src/components/header/Dropdown.tsx
+++ b/src/components/header/Dropdown.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { Link, useLocation } from "react-router-dom";
 import styled from "styled-components";
 import { DropdownForm } from "../../types/Dropdown";
@@ -88,6 +88,7 @@ const LogoutButton = styled.button`
 
 export default function Dropdown({ handleLogout }: DropdownForm) {
   const location = useLocation();
+  const dropdownRef = useRef<HTMLUListElement | null>(null);
 
   // 경로에 따른 동적 색상 설정
   const color = location.pathname === "/" ? "#fff" : "#333";
@@ -97,6 +98,16 @@ export default function Dropdown({ handleLogout }: DropdownForm) {
   // 상태 관리: 목록이 보이는지 여부를 결정하는 state
   const [isOpen, setIsOpen] = useState(false);
   const [nicknameData, setNicknameData] = useState("");
+
+  const handleClickOutside = (event: MouseEvent) => {
+    if (
+      dropdownRef.current &&
+      !dropdownRef.current.contains(event.target as Node)
+    ) {
+      setIsOpen(false);
+    }
+  };
+
   useEffect(() => {
     const nicknameAPI = async () => {
       const nicknameData = await Api({
@@ -110,6 +121,12 @@ export default function Dropdown({ handleLogout }: DropdownForm) {
       }
     };
     nicknameAPI();
+    // 어딜 클릭하던 실행
+    document.addEventListener("mousedown", handleClickOutside);
+    // 클린업 함수
+    return () => {
+      document.removeEventListener("mousedown", handleClickOutside);
+    };
   }, []);
 
   // 토글 함수
@@ -144,7 +161,7 @@ export default function Dropdown({ handleLogout }: DropdownForm) {
       </DropText>
       {/* 상태에 따라 목록 표시 */}
       {isOpen && (
-        <Ul>
+        <Ul ref={dropdownRef}>
           <Li>
             <StyledLink to="/mypage">
               <img src={myImg} alt="마이페이지" />

--- a/src/pages/Detail.tsx
+++ b/src/pages/Detail.tsx
@@ -68,6 +68,7 @@ const Synergy = styled.li`
   border-radius: 5px;
   background: #fff;
   cursor: pointer;
+  box-shadow: 0px 4px 10px rgba(0, 0, 0, 0.1);
   > p {
     padding-left: 2.5px;
     padding-right: 2px;
@@ -96,7 +97,7 @@ const ChessBox = styled.div`
   width: 845px;
   height: 492px;
   background: #fff;
-  box-shadow: 0px 4px 36px -14px rgba(0, 0, 0, 0.05);
+  box-shadow: 0px 4px 10px rgba(0, 0, 0, 0.1);
 `;
 const Top = styled.div`
   display: flex;
@@ -221,7 +222,7 @@ const Comment = styled.div`
   width: 334px;
   height: 490px;
   background: #fff;
-  box-shadow: 0px 4px 36px -14px rgba(0, 0, 0, 0.05);
+  box-shadow: 0px 4px 10px rgba(0, 0, 0, 0.1);
 `;
 const CommentTitle = styled.div`
   height: 66px;

--- a/src/pages/Detail.tsx
+++ b/src/pages/Detail.tsx
@@ -22,6 +22,7 @@ import dislikeClickImg from "../assets/icon/dislike_click.svg";
 import lineImg from "../assets/icon/line.svg";
 import moneyImg from "../assets/icon/money.svg";
 import Chat from "../components/Chat";
+import getCookie from "../utils/cookies/getCookie";
 
 const Body = styled.div`
   display: flex;
@@ -30,6 +31,7 @@ const Body = styled.div`
 `;
 
 const Main = styled.main`
+  position: relative;
   flex: 1;
   background-color: #f4f4f4;
   display: flex;
@@ -37,6 +39,15 @@ const Main = styled.main`
   align-items: center;
   gap: 19px;
   padding: 25px 0 90px;
+  > small {
+    position: absolute;
+    top: 55px;
+    left: 50%;
+    transform: translate(125%);
+    font-size: 11px;
+    font-weight: 400;
+    color: #5661ff;
+  }
 `;
 
 const SynergyBox = styled.ul`
@@ -231,9 +242,10 @@ const LikeButton = styled.div`
   font-weight: 500;
   color: #3d3d3d;
   font-family: "Roboto";
-  > img {
-    cursor: pointer;
-  }
+`;
+const Buttons = styled.button`
+  all: unset; /* 버튼의 기본 스타일 제거 */
+  cursor: pointer;
 `;
 const TooltipImg = styled.img`
   filter: invert(1);
@@ -272,9 +284,13 @@ export default function Detail() {
   const { id } = useParams(); // URL에서 id 값 가져오기
   const [data, setData] = useState<ListForm>(); // api에서 받아온 메타 정보
   const [heart, setHeart] = useState(false); // 빈하트 false
+  const [like, setLike] = useState(false); // 빈좋아요 false
+  const [dislike, setDislike] = useState(false); // 빈좋아요 false
   const [synergyTooltip, setSynergyTooltip] = useState<any>(); // 시너지 툴팁 on/off
   const [championTooltip, setChampionTooltip] = useState<any>(); // 챔피언 툴팁 on/off
   const [itemTooltip, setItemTooltip] = useState<any>(); // 아이템 툴팁 on/off
+
+  const token = getCookie("token"); // 현재 토큰
 
   useEffect(() => {
     const searchApi = async () => {
@@ -399,6 +415,40 @@ export default function Detail() {
     setHeart(!heart);
   };
 
+  const handleLike = () => {
+    if (token && id) {
+      if (like) {
+        setLike(false);
+        setDislike(true);
+      } else {
+        setLike(true);
+        Api({
+          bodyData: { id: parseInt(id, 10), action: "like" },
+          method: "POST",
+          lastUrl: "meta/reaction/",
+        });
+        setDislike(false);
+      }
+    }
+  };
+
+  const handleDislike = () => {
+    if (token && id) {
+      if (dislike) {
+        setDislike(false);
+        setLike(true);
+      } else {
+        setDislike(true);
+        Api({
+          bodyData: { id: parseInt(id, 10), action: "dislike" },
+          method: "POST",
+          lastUrl: "meta/reaction/",
+        });
+        setLike(false);
+      }
+    }
+  };
+
   return (
     <Body>
       <header>
@@ -482,16 +532,27 @@ export default function Detail() {
             <CommentTitle>
               <h4>덱이 마음에 드셨나요?</h4>
               <LikeButton>
-                <img src={likeImg} alt="좋아요" />
+                <Buttons type="button" onClick={handleLike}>
+                  <img src={like ? likeClickImg : likeImg} alt="좋아요" />
+                </Buttons>
                 <img src={lineImg} alt="실선" />
-                {Preference(data?.meta.like_count, data?.meta.dislike_count)}
-                %
-                <img src={dislikeImg} alt="싫어요" />
+                {Preference(data?.meta.like_count, data?.meta.dislike_count)}%
+                <Buttons type="button" onClick={handleDislike}>
+                  <img
+                    src={dislike ? dislikeClickImg : dislikeImg}
+                    alt="싫어요"
+                  />
+                </Buttons>
               </LikeButton>
             </CommentTitle>
             <Chat metaid={id} />
           </Comment>
         </Contents>
+        {!token && (
+          <small>
+            *로그인 시 즐겨찾기, 선호도, 채팅 기능을 이용할 수 있습니다!
+          </small>
+        )}
       </Main>
       <footer>
         <Footer />

--- a/src/pages/Detail.tsx
+++ b/src/pages/Detail.tsx
@@ -412,7 +412,23 @@ export default function Detail() {
   }
 
   const handleHeart = () => {
-    setHeart(!heart);
+    if (token && id) {
+      if (heart) {
+        setHeart(false);
+        Api({
+          bodyData: { id: parseInt(id, 10) },
+          method: "DELETE",
+          lastUrl: "user/deletefavorite/",
+        });
+      } else {
+        setHeart(true);
+        Api({
+          bodyData: { id: parseInt(id, 10) },
+          method: "POST",
+          lastUrl: "user/favorite/",
+        });
+      }
+    }
   };
 
   const handleLike = () => {

--- a/src/pages/Favorites.tsx
+++ b/src/pages/Favorites.tsx
@@ -1,7 +1,12 @@
 import styled from "styled-components";
+import { useEffect, useState } from "react";
+import Skeleton from "react-loading-skeleton";
 import Header from "../components/containers/Header";
 import Footer from "../components/containers/Footer";
 import mypageImg from "../assets/img/mypage.png";
+import Meta from "../components/common/Meta";
+import { ListForm } from "../types/List";
+import { Api } from "../utils/apis/Api";
 
 const Body = styled.div`
   display: flex;
@@ -46,10 +51,50 @@ const Image = styled.img`
 `;
 
 const Contents = styled.div`
-  height: 80vh;
+  display: flex;
+  justify-content: center;
+  width: 100%;
+  height: 100%;
+  padding: 50px 20px 100px 20px;
 `;
 
 export default function Favorites() {
+  const [metaData, setMetaData] = useState<ListForm[] | null>(null);
+  const [isLoading, setIsLoading] = useState(true);
+
+  useEffect(() => {
+    const searchApi = async () => {
+      setIsLoading(true);
+      const response = await Api({
+        method: "GET",
+        lastUrl: "user/checkfavorite/",
+      });
+      console.log(response.data);
+      setMetaData(response.data);
+      setIsLoading(false);
+    };
+    searchApi();
+  }, []);
+
+  const renderContent = () => {
+    // 로딩 상태
+    if (isLoading) {
+      return (
+        <Skeleton
+          height="550px"
+          width="1004px"
+          baseColor="#DCDCDC"
+          borderRadius="27px"
+        />
+      );
+    }
+    // 데이터가 있을 때
+    if (metaData && metaData.length > 0) {
+      return <Meta metaData={metaData} />;
+    }
+    // 데이터가 없을 때
+    return <h2>아직 즐겨찾기한 항목이 없습니다.</h2>;
+  };
   return (
     <Body>
       <header>
@@ -64,7 +109,7 @@ export default function Favorites() {
             <Image src={mypageImg} alt="즐겨찾기 이미지" />
           </DivBox>
         </ImageBox>
-        <Contents>ㅇ</Contents>
+        <Contents>{renderContent()}</Contents>
       </Main>
       <footer>
         <Footer />

--- a/src/pages/Favorites.tsx
+++ b/src/pages/Favorites.tsx
@@ -7,6 +7,7 @@ import mypageImg from "../assets/img/mypage.png";
 import Meta from "../components/common/Meta";
 import { ListForm } from "../types/List";
 import { Api } from "../utils/apis/Api";
+import infoImg from "../assets/icon/info.svg";
 
 const Body = styled.div`
   display: flex;
@@ -58,6 +59,39 @@ const Contents = styled.div`
   padding: 50px 20px 100px 20px;
 `;
 
+const InfoBox = styled.div`
+  width: 1004px;
+  height: 300px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 15px;
+  color: #3b3b3b;
+  font-weight: 400;
+  line-height: 150%; /* 24px */
+  letter-spacing: -0.048px;
+  > img {
+    width: 66px;
+    height: 66px;
+  }
+  > h2 {
+    color: #0d0d0d;
+    font-size: 33px;
+    font-style: normal;
+    font-weight: 700;
+    line-height: 148%; /* 48.84px */
+    letter-spacing: -0.099px;
+  }
+  > a {
+    text-decoration: none;
+    color: #3884ff;
+    font-weight: 600;
+    &:hover {
+      text-decoration: underline;
+    }
+  }
+`;
+
 export default function Favorites() {
   const [metaData, setMetaData] = useState<ListForm[] | null>(null);
   const [isLoading, setIsLoading] = useState(true);
@@ -81,7 +115,7 @@ export default function Favorites() {
     if (isLoading) {
       return (
         <Skeleton
-          height="550px"
+          height="300px"
           width="1004px"
           baseColor="#DCDCDC"
           borderRadius="27px"
@@ -93,8 +127,18 @@ export default function Favorites() {
       return <Meta metaData={metaData} />;
     }
     // 데이터가 없을 때
-    return <h2>아직 즐겨찾기한 항목이 없습니다.</h2>;
+    return (
+      <InfoBox>
+        <img src={infoImg} alt="즐겨찾기없음" />
+        <h2>즐겨찾기</h2>
+        <p>즐겨찾는 메타가 없습니다. 메타를 추가해보세요.</p>
+        <a href="https://www.findlolchess.kro.kr/recommend-list">
+          추천메타 바로가기
+        </a>
+      </InfoBox>
+    );
   };
+
   return (
     <Body>
       <header>

--- a/src/pages/Favorites.tsx
+++ b/src/pages/Favorites.tsx
@@ -60,8 +60,9 @@ const Contents = styled.div`
 `;
 
 const InfoBox = styled.div`
+  padding: 100px;
   width: 1004px;
-  height: 300px;
+  height: 460px;
   display: flex;
   flex-direction: column;
   align-items: center;


### PR DESCRIPTION
1. 즐겨찾기
- 로그인 시 사용 가능
- 하트 클릭 시 활성화, 이미 눌린 하트 한 번 더 클릭 시 비활성화

![image](https://github.com/user-attachments/assets/ed2f377e-f3f5-49d2-9907-9f584df30603)

![image](https://github.com/user-attachments/assets/72085013-c904-4973-946a-176e633c7944)

- 토큰을 통해 유저가 이전에 눌렀던 하트를 기억해서 덱마다 눌린 하트를 다르게 표시
- 나의 즐겨찾기 페이지 디자인 : 즐겨찾기 있을 시 즐겨찾기 된 메타 표출/없을 시 없다고 공지 후 추천 메타 추천하는 링크

![image](https://github.com/user-attachments/assets/eddc1e97-afb5-4f6e-bfb7-83fc1c80af2e)

![image](https://github.com/user-attachments/assets/7ea7935a-f6cc-4a9e-9a9a-caba00028ac1)

- 유저가 즐겨찾기 눌러둔 덱 메타상 표출

2. 드롭다운
- 드롭다운(헤더, 댓글) 밖 부분 누르면 닫히는 기능 구현
- 댓글 드롭다운 디자인
- 댓글 드롭다운 기능 : 댓글 수정(setIsEdit), 댓글 삭제(handleDelete)

![image](https://github.com/user-attachments/assets/7aab11ef-e37d-4325-a0d0-fd03416f054b)

3. 댓글 삭제 
- handleDelete : api상 댓글 삭제, setMessages를 통해 방금 삭제한 id말고 나머지를 다시 messages에 저장
- onSubmit : 새로고침 없이 바로 댓글이 사라지는 걸 보여주기 위해, 등록 버튼 누를 시 get을 한 번 더 불러옴. 

4. 댓글 수정
- isEdit : 0일땐 수정된 데이터가 아님, id를 받기 때문에 수정한 댓글의 id를 받아옴. 만약 수정한 댓글 id가 있다면 기본 input과 달리 수정 버전 input 디자인으로 변경
- 수정 버전 input 디자인 : 타이틀 "수정중.." 추가. 배경색상 변경, placeholder에 수정 전 내용 표출.
- onSubmit : isEdit이 0이 아닐때, 수정 중인 상태니깐 patch를 통해 수정된 데이터를 보냄.
- chatApi : 연속된 사용으로 구조화

![image](https://github.com/user-attachments/assets/701eb197-85e1-4fa9-9025-2fe3aebb4f48)

5. 선호도
- 로그인 시 사용 가능
- 좋아요 누를 시 싫어요는 자동 비활성화
- 싫어요 누를 시 좋아요는 자동 비활성화
- 좋아요/싫어요 연속으로 클릭 시 직전에 누른 버튼 비활성화
- 실시간 선호도 비율 반영
- 토큰을 통해 유저가 이전 눌렀던 버튼을 기억해서 덱마다 눌려 있는 좋아요/싫어요 버튼 표시