### PR TITLE
🔖시즌 15

### DIFF
--- a/src/components/Fast.tsx
+++ b/src/components/Fast.tsx
@@ -289,9 +289,8 @@ export default function Fast({
                   .filter(
                     (item: ChampionDataForm) =>
                       item.price === price &&
-                      item.name !== "T-43X" &&
-                      item.name !== "R-080T" &&
-                      item.name !== "공허생물",
+                      item.name !== "휘감는뿌리" &&
+                      item.name !== "거대메크로봇",
                   )
                   .map((item: ChampionDataForm) => (
                     <Champion

--- a/src/utils/meta/ChampionColor.ts
+++ b/src/utils/meta/ChampionColor.ts
@@ -1,7 +1,7 @@
 export default function ChampionColor(price: number, name?: string) {
-  // 사이온
-  if (name === "T-43X" || name === "R-080T" || name === "공허생물") {
-    return "#000";
+  // 시즌13:사이온, 시즌14:T-43X,R-080T,공허생물, 시즌15:휘감는뿌리,거대메크로봇
+  if (name === "휘감는뿌리" || name === "거대메크로봇") {
+    return "#0d0d0d";
   }
   // 1코인
   if (price === 1) {


### PR DESCRIPTION
바뀐 시즌에 맞게 조건 변경

1. main 브랜치

- 썸네일 변경
- 문구 수정(캐러셀, 빠챔 문구 등)
- 캐러셀 변경
- 빠챔 배너 변경

2. black 브랜치

- 이번 시즌 black 테두리에 해당하는 챔피언 메타에서 수정(휘감는뿌리, 거대메크로봇)
- 빠챔에서 black 테두리에 해당하는 챔피언 disabled(휘감는뿌리, 거대메크로봇)
- 상세 페이지에서 championTooltip 예외 적용(휘감는뿌리, 거대메크로봇)

>  **프론트엔드 배포 환경 변경**
기존 aws 환경 -> 오라클 클라우드 환경

